### PR TITLE
Add Dynamic Table Support, Configurable Browser Path, and Table Width Option

### DIFF
--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -11,7 +11,8 @@ Module.register("MMM-Scrapey", {
         showTableHeader: true, // Toggle header row formatting
         plainText: false, // If true, ignore any HTML formatting and just display the text
         title: "Scrapey Data", // Default header text
-        waitForSelector: false // Wait for selector to appear (for JS-loaded tables)
+        waitForSelector: false, // Wait for selector to appear (for JS-loaded tables)
+        browserPath: "/usr/bin/chromium-browser" // Default browser path for puppeteer
     },
 
     start: function () {
@@ -29,7 +30,8 @@ Module.register("MMM-Scrapey", {
             instanceId: this.instanceId,
             url: this.config.url,
             cssSelector: this.config.cssSelector,
-            waitForSelector: this.config.waitForSelector // Add this line
+            waitForSelector: this.config.waitForSelector,
+            browserPath: this.config.browserPath // Pass browser path
         });
     },
 

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -54,8 +54,8 @@ Module.register("MMM-Scrapey", {
 
         if (table) {
             var filteredTable = document.createElement("table");
-            // Handle header if showHeader is true
-            if (this.config.showHeader) {
+            // Handle header if showTableHeader is true
+            if (this.config.showTableHeader) {
                 var thead = filteredTable.createTHead();
                 var headerRow = thead.insertRow();
                 var originalHeaderRow = table.tHead ? table.tHead.rows[0] : table.tBodies[0].rows[0];

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -10,7 +10,8 @@ Module.register("MMM-Scrapey", {
         tableRows: [], // Specify which rows to display (1-based index), leave empty to show all
         showTableHeader: true, // Toggle header row formatting
         plainText: false, // If true, ignore any HTML formatting and just display the text
-        title: "Scrapey Data" // Default header text
+        title: "Scrapey Data", // Default header text
+        waitForSelector: false // Wait for selector to appear (for JS-loaded tables)
     },
 
     start: function () {
@@ -27,7 +28,8 @@ Module.register("MMM-Scrapey", {
         this.sendSocketNotification("FETCH_SCRAPE_DATA", {
             instanceId: this.instanceId,
             url: this.config.url,
-            cssSelector: this.config.cssSelector
+            cssSelector: this.config.cssSelector,
+            waitForSelector: this.config.waitForSelector // Add this line
         });
     },
 

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -12,7 +12,8 @@ Module.register("MMM-Scrapey", {
         plainText: false, // If true, ignore any HTML formatting and just display the text
         title: "Scrapey Data", // Default header text
         waitForSelector: false, // Wait for selector to appear (for JS-loaded tables)
-        browserPath: "/usr/bin/chromium-browser" // Default browser path for puppeteer
+        browserPath: "/usr/bin/chromium-browser", // Default browser path for puppeteer
+        tableWidth: "100%" // <--- Add this line for width preset
     },
 
     start: function () {
@@ -54,6 +55,9 @@ Module.register("MMM-Scrapey", {
 
         if (table) {
             var filteredTable = document.createElement("table");
+            // Set table width from config
+            filteredTable.style.width = this.config.tableWidth;
+
             // Handle header if showTableHeader is true
             if (this.config.showTableHeader) {
                 var thead = filteredTable.createTHead();

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Module for [MagicMirror²](https://github.com/MichMich/MagicMirror/), to scrape content from any table on a webpage, choose which rows and columns you want, and how often you want to refresh the display on your mirror.
 
 ![Alt text](/img/demo.png "A preview of the MMM-Scrapey module showing bus times.")
-![Alt text](/img/demo-2.png "A preview of the MMM-Scrapey module readong from a scrape test page.")
+![Alt text](/img/demo-2.png "A preview of the MMM-Scrapey module reading from a scrape test page.")
 
 ## Installing
 
 ### Step 1 - Install the module
-```javascript
+```sh
 cd ~/MagicMirror/modules
 git clone https://github.com/AndyHazz/MMM-Scrapey.git
 cd MMM-Scrapey
@@ -16,8 +16,8 @@ npm install
 ```
 
 ### Step 2 - Add module to `~MagicMirror/config/config.js`
-Add this configuration into `config.js` file's
-```json5
+Add this configuration into your `config.js` file:
+```js
 {
     module: "MMM-Scrapey",
     position: "lower_third",
@@ -25,17 +25,57 @@ Add this configuration into `config.js` file's
         title: "Scrapey module", // Optional - remove or leave empty for no title
         url: "https://webscraper.io/test-sites/tables", // The URL of the page with the table to scrape
         updateInterval: 300, // Refresh time in seconds
-        cssSelector: "table", // 'table' should select the first table on the page, or use CSS selectors to be more specific
+        cssSelector: "table", // CSS selector for the table to scrape
         tableColumns: [1,3,4], // Specify which columns to display (1-based index)
         tableRows: [1,2,3], // Specify which rows to display (1-based index), leave empty to show all
         showTableHeader: true, // Toggle formatting the first row as a table header
-        plainText: true // Strip out any extra HTML and just keep the plain text content
+        plainText: true, // Strip out any extra HTML and just keep the plain text content
+        waitForSelector: false, // Set to true if the table loads dynamically via JavaScript
+        browserPath: "/usr/bin/chromium-browser", // Path to Chromium/Chrome for Puppeteer (change if needed)
+        tableWidth: "100%" // Set table width (e.g., "100%", "1200px", etc.)
     }
 },
 ```
+
+### Dynamic Table Support
+
+If the table you want to scrape loads via JavaScript (not present in the initial HTML), set `waitForSelector: true` in your config.  
+**Note:** You must have [Puppeteer](https://pptr.dev/) and a compatible version of Chromium/Chrome installed.  
+You can specify the path to your browser with `browserPath`.  
+On Raspberry Pi, this is usually `/usr/bin/chromium-browser` or `/usr/bin/chromium`.
+
+### Example for Raspberry Pi
+```js
+config: {
+    // ...other config...
+    waitForSelector: true,
+    browserPath: "/usr/bin/chromium"
+}
+```
+
 ## Updating
 Go to the module’s folder inside MagicMirror modules folder and pull the latest version from GitHub and install:
-```
+```sh
 git pull
 npm install
 ```
+
+## Configuration Options
+
+| Option           | Type      | Default                        | Description                                                                 |
+|------------------|-----------|--------------------------------|-----------------------------------------------------------------------------|
+| `title`          | string    | "Scrapey Data"                 | Module header text                                                          |
+| `url`            | string    | *required*                     | URL of the page to scrape                                                   |
+| `updateInterval` | int       | 60                             | Refresh interval in seconds                                                 |
+| `cssSelector`    | string    | "table"                        | CSS selector for the table to scrape                                        |
+| `tableColumns`   | array     | [1,2,3]                        | Columns to display (1-based index)                                          |
+| `tableRows`      | array     | []                             | Rows to display (1-based index, empty for all)                              |
+| `showTableHeader`| boolean   | true                           | Show the table header row                                                   |
+| `plainText`      | boolean   | false                          | Display only plain text (no HTML)                                           |
+| `waitForSelector`| boolean   | false                          | Wait for selector (for JS-loaded tables, requires Puppeteer)                |
+| `browserPath`    | string    | "/usr/bin/chromium-browser"    | Path to Chromium/Chrome for Puppeteer                                       |
+| `tableWidth`     | string    | "100%"                         | CSS width for the table (e.g., "100%", "1200px")                            |
+
+---
+
+For troubleshooting Puppeteer or browser issues, see

--- a/node_helper.js
+++ b/node_helper.js
@@ -54,6 +54,9 @@ module.exports = NodeHelper.create({
             const page = await browser.newPage();
             await page.goto(scrapeURL, { waitUntil: 'networkidle2' });
             await page.waitForSelector(cssSelector, { timeout: 15000 });
+
+            console.info(`[MMM-Scrapey][INFO] Selector "${cssSelector}" appeared, starting scrape for instanceId: ${instanceId}`);
+
             const scrapedData = await page.$eval(cssSelector, el => el.innerHTML);
             await browser.close();
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -12,7 +12,7 @@ module.exports = NodeHelper.create({
     socketNotificationReceived: function (notification, payload) {
         if (notification === "FETCH_SCRAPE_DATA") {
             if (payload.waitForSelector && puppeteer) {
-                this.fetchDataWithPuppeteer(payload.url, payload.cssSelector, payload.instanceId);
+                this.fetchDataWithPuppeteer(payload.url, payload.cssSelector, payload.instanceId, payload.browserPath);
             } else {
                 this.fetchData(payload.url, payload.cssSelector, payload.instanceId);
             }
@@ -45,9 +45,12 @@ module.exports = NodeHelper.create({
             });
     },
 
-    fetchDataWithPuppeteer: async function (scrapeURL, cssSelector, instanceId) {
+    fetchDataWithPuppeteer: async function (scrapeURL, cssSelector, instanceId, browserPath) {
         try {
-            const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+            const browser = await puppeteer.launch({
+                args: ['--no-sandbox'],
+                executablePath: browserPath || '/usr/bin/chromium-browser'
+            });
             const page = await browser.newPage();
             await page.goto(scrapeURL, { waitUntil: 'networkidle2' });
             await page.waitForSelector(cssSelector, { timeout: 15000 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "cheerio": "^1.0.0",
-    "puppeteer": "^22.0.0"
+    "puppeteer": "^22.0.0",
+    "node-fetch": "^2.6.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "cheerio": "^1.0.0"
+    "cheerio": "^1.0.0",
+    "puppeteer": "^22.0.0"
   }
 }


### PR DESCRIPTION
This pull request adds several enhancements and fixes to MMM-Scrapey:

# Use Case
Many web pages use JavaScript to load tables dynamically after the initial page load. Previously, this module was not compatible with such pages (e.g., https://gw2mists.com/matches/na), as the scraper would not find the table in the static HTML. With these changes, the module can optionally use Puppeteer to wait for the table selector to appear, ensuring compatibility with JavaScript-rendered tables. While this approach is more resource-intensive, it provides a reliable way to scrape tables that are loaded asynchronously.

# Changelog
**Dynamic Table Support:**
Adds the ability to scrape tables that are loaded via JavaScript by optionally using Puppeteer and waiting for a selector to appear before scraping.

**Configurable Browser Path:**
Introduces a `browserPath` config option, allowing users to specify the path to their Chromium/Chrome executable. This is especially useful for ARM devices like Raspberry Pi.

**Table Width Configuration:**
Adds a `tableWidth` config option so users can set the CSS width of the displayed table (e.g., "100%", "1200px").

**Improved Logging:**
Adds an `[INFO]` log message when Puppeteer begins scraping after the selector appears.

**Bugfix:**
Ensures the `showTableHeader` config is respected when rendering the table header.

**Documentation:**
Updates the README to reflect new configuration options and usage instructions.

These changes improve compatibility with dynamic web pages, enhance user configurability, and provide better feedback and documentation.

# Testing
- [x] Ensure that the code works without setting the `waitForSelector`
- [x] Ensure that the browser source works for Raspberry Pi devices
- [x] Ensure that the `showTableHeader` is properly respected
- [x] Ensure that the new `tableWidth` configuration is properly respected