### PR TITLE
Add Bright Text and Configurable Row Opacity Options

### DIFF
--- a/MMM-Scrapey.css
+++ b/MMM-Scrapey.css
@@ -1,0 +1,4 @@
+.bright {
+    color: #fff !important;
+    text-shadow: 0 0 2px #fff, 0 0 5px #fff;
+}

--- a/MMM-Scrapey.css
+++ b/MMM-Scrapey.css
@@ -1,4 +1,3 @@
 .bright {
     color: #fff !important;
-    text-shadow: 0 0 2px #fff, 0 0 5px #fff;
 }

--- a/MMM-Scrapey.css
+++ b/MMM-Scrapey.css
@@ -3,5 +3,5 @@
 }
 
 .scrapey-row {
-    opacity: 0.92;
+    opacity: 0.80;
 }

--- a/MMM-Scrapey.css
+++ b/MMM-Scrapey.css
@@ -1,7 +1,0 @@
-.bright {
-    color: #fff !important;
-}
-
-.scrapey-row {
-    opacity: 0.7;
-}

--- a/MMM-Scrapey.css
+++ b/MMM-Scrapey.css
@@ -1,3 +1,7 @@
 .bright {
     color: #fff !important;
 }
+
+.scrapey-row {
+    opacity: 0.92;
+}

--- a/MMM-Scrapey.css
+++ b/MMM-Scrapey.css
@@ -3,5 +3,5 @@
 }
 
 .scrapey-row {
-    opacity: 0.80;
+    opacity: 0.7;
 }

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -14,8 +14,14 @@ Module.register("MMM-Scrapey", {
         waitForSelector: false, // Wait for selector to appear (for JS-loaded tables)
         browserPath: "/usr/bin/chromium-browser", // Default browser path for puppeteer
         tableWidth: "100%", // <--- Add this line for width preset
-        rowOpacity: null,      // Opacity for table rows (null means no style applied)
-        headerOpacity: null,   // Opacity for table header (null means no style applied)
+        headerStyle: {
+            opacity: null,   // e.g. 1.0
+            color: null      // e.g. "#fff"
+        },
+        rowStyle: {
+            opacity: null,   // e.g. 0.92
+            color: null      // e.g. "#fff"
+        }
     },
 
     start: function () {
@@ -76,8 +82,11 @@ Module.register("MMM-Scrapey", {
                     if (cell) {
                         var th = document.createElement("th");
                         th.innerHTML = cell.innerHTML;
-                        if (this.config.headerOpacity !== null) {
-                            th.style.opacity = this.config.headerOpacity;
+                        if (this.config.headerStyle.opacity !== null) {
+                            th.style.opacity = this.config.headerStyle.opacity;
+                        }
+                        if (this.config.headerStyle.color !== null) {
+                            th.style.color = this.config.headerStyle.color;
                         }
                         headerRow.appendChild(th);
                     }
@@ -95,8 +104,8 @@ Module.register("MMM-Scrapey", {
                 var row = rows[rowIndex - 1];
                 if (row) {
                     var newRow = tbody.insertRow();
-                    if (this.config.rowOpacity !== null) {
-                        newRow.style.opacity = this.config.rowOpacity;
+                    if (this.config.rowStyle.opacity !== null) {
+                        newRow.style.opacity = this.config.rowStyle.opacity;
                     }
                     this.config.tableColumns.forEach((colIndex) => {
                         var cell = row.cells[colIndex - 1];

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -14,7 +14,8 @@ Module.register("MMM-Scrapey", {
         waitForSelector: false, // Wait for selector to appear (for JS-loaded tables)
         browserPath: "/usr/bin/chromium-browser", // Default browser path for puppeteer
         tableWidth: "100%", // <--- Add this line for width preset
-        brightText: false   // <--- Add this line for bright text option
+        brightText: false,   // <--- Add this line for bright text option
+        rowOpacity: 0.92, // Default opacity for table rows
     },
 
     start: function () {
@@ -61,7 +62,7 @@ Module.register("MMM-Scrapey", {
 
             // Apply bright text style if enabled
             if (this.config.brightText) {
-                filteredTable.classList.add("bright");
+                filteredTable.style.color = "#fff";
             }
 
             // Handle header if showTableHeader is true
@@ -96,7 +97,11 @@ Module.register("MMM-Scrapey", {
                 var row = rows[rowIndex - 1];
                 if (row) {
                     var newRow = tbody.insertRow();
-                    newRow.classList.add("scrapey-row"); // Use the correct class name
+                    // Only add opacity class if brightText is false
+                    if (!this.config.brightText) {
+                        newRow.classList.add("scrapey-row");
+                        newRow.style.opacity = this.config.rowOpacity; // Set opacity from config
+                    }
                     this.config.tableColumns.forEach((colIndex) => {
                         var cell = row.cells[colIndex - 1];
                         if (cell) {
@@ -122,8 +127,4 @@ Module.register("MMM-Scrapey", {
     getHeader: function () {
         return this.config.title;
     },
-
-    getStyles: function () {
-        return ["MMM-Scrapey.css"];
-    }
 });

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -98,7 +98,7 @@ Module.register("MMM-Scrapey", {
                 if (row) {
                     var newRow = tbody.insertRow();
                     // Only add opacity class if brightText is false
-                    if (!this.config.brightText) {
+                    if (this.config.brightText) {
                         newRow.classList.add("scrapey-row");
                         newRow.style.opacity = this.config.rowOpacity; // Set opacity from config
                     }

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -96,7 +96,7 @@ Module.register("MMM-Scrapey", {
                 var row = rows[rowIndex - 1];
                 if (row) {
                     var newRow = tbody.insertRow();
-                    newRow.classList.add("scrapey"); // Add class "scrapey" to each new row
+                    newRow.classList.add("scrapey-row"); // Use the correct class name
                     this.config.tableColumns.forEach((colIndex) => {
                         var cell = row.cells[colIndex - 1];
                         if (cell) {

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -14,8 +14,8 @@ Module.register("MMM-Scrapey", {
         waitForSelector: false, // Wait for selector to appear (for JS-loaded tables)
         browserPath: "/usr/bin/chromium-browser", // Default browser path for puppeteer
         tableWidth: "100%", // <--- Add this line for width preset
-        brightText: false,   // <--- Add this line for bright text option
-        rowOpacity: 0.92, // Default opacity for table rows
+        rowOpacity: null,      // Opacity for table rows (null means no style applied)
+        headerOpacity: null,   // Opacity for table header (null means no style applied)
     },
 
     start: function () {
@@ -60,11 +60,6 @@ Module.register("MMM-Scrapey", {
             // Set table width from config
             filteredTable.style.width = this.config.tableWidth;
 
-            // Apply bright text style if enabled
-            if (this.config.brightText) {
-                filteredTable.style.color = "#fff";
-            }
-
             // Handle header if showTableHeader is true
             if (this.config.showTableHeader) {
                 var thead = filteredTable.createTHead();
@@ -81,6 +76,9 @@ Module.register("MMM-Scrapey", {
                     if (cell) {
                         var th = document.createElement("th");
                         th.innerHTML = cell.innerHTML;
+                        if (this.config.headerOpacity !== null) {
+                            th.style.opacity = this.config.headerOpacity;
+                        }
                         headerRow.appendChild(th);
                     }
                 });
@@ -97,10 +95,8 @@ Module.register("MMM-Scrapey", {
                 var row = rows[rowIndex - 1];
                 if (row) {
                     var newRow = tbody.insertRow();
-                    // Only add opacity class if brightText is false
-                    if (this.config.brightText) {
-                        newRow.classList.add("scrapey-row");
-                        newRow.style.opacity = this.config.rowOpacity; // Set opacity from config
+                    if (this.config.rowOpacity !== null) {
+                        newRow.style.opacity = this.config.rowOpacity;
                     }
                     this.config.tableColumns.forEach((colIndex) => {
                         var cell = row.cells[colIndex - 1];

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -96,6 +96,7 @@ Module.register("MMM-Scrapey", {
                 var row = rows[rowIndex - 1];
                 if (row) {
                     var newRow = tbody.insertRow();
+                    newRow.classList.add("scrapey"); // Add class "scrapey" to each new row
                     this.config.tableColumns.forEach((colIndex) => {
                         var cell = row.cells[colIndex - 1];
                         if (cell) {

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -13,7 +13,8 @@ Module.register("MMM-Scrapey", {
         title: "Scrapey Data", // Default header text
         waitForSelector: false, // Wait for selector to appear (for JS-loaded tables)
         browserPath: "/usr/bin/chromium-browser", // Default browser path for puppeteer
-        tableWidth: "100%" // <--- Add this line for width preset
+        tableWidth: "100%", // <--- Add this line for width preset
+        brightText: false   // <--- Add this line for bright text option
     },
 
     start: function () {
@@ -57,6 +58,11 @@ Module.register("MMM-Scrapey", {
             var filteredTable = document.createElement("table");
             // Set table width from config
             filteredTable.style.width = this.config.tableWidth;
+
+            // Apply bright text style if enabled
+            if (this.config.brightText) {
+                filteredTable.classList.add("bright");
+            }
 
             // Handle header if showTableHeader is true
             if (this.config.showTableHeader) {
@@ -114,5 +120,9 @@ Module.register("MMM-Scrapey", {
 
     getHeader: function () {
         return this.config.title;
+    },
+
+    getStyles: function () {
+        return ["MMM-Scrapey.css"];
     }
 });

--- a/MMM-Scrapey.js
+++ b/MMM-Scrapey.js
@@ -107,6 +107,9 @@ Module.register("MMM-Scrapey", {
                     if (this.config.rowStyle.opacity !== null) {
                         newRow.style.opacity = this.config.rowStyle.opacity;
                     }
+                    if (this.config.rowStyle.color !== null) {
+                        newRow.style.color = this.config.rowStyle.color;
+                    }
                     this.config.tableColumns.forEach((colIndex) => {
                         var cell = row.cells[colIndex - 1];
                         if (cell) {

--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ npm install
 | `waitForSelector` | boolean   | false                          | Wait for selector (for JS-loaded tables, requires Puppeteer)                |
 | `browserPath`     | string    | "/usr/bin/chromium-browser"    | Path to Chromium/Chrome for Puppeteer                                       |
 | `tableWidth`      | string    | "100%"                         | CSS width for the table (e.g., "100%", "1200px")                            |
-| `brightText`      | boolean   | false                          | Use bright white text and subtle glow for the table                         |
-| `rowOpacity`      | number    | 0.92                           | Opacity for table rows (0.0–1.0, ignored if `brightText` is `false`)           |
+| `rowOpacity`      | number\|null | null                        | Opacity for table rows (0.0–1.0, null for no style)                         |
+| `headerOpacity`   | number\|null | null                        | Opacity for table header (0.0–1.0, null for no style)                       |

--- a/README.md
+++ b/README.md
@@ -62,20 +62,36 @@ npm install
 
 ## Configuration Options
 
-| Option           | Type      | Default                        | Description                                                                 |
-|------------------|-----------|--------------------------------|-----------------------------------------------------------------------------|
-| `title`          | string    | "Scrapey Data"                 | Module header text                                                          |
-| `url`            | string    | *required*                     | URL of the page to scrape                                                   |
-| `updateInterval` | int       | 60                             | Refresh interval in seconds                                                 |
-| `cssSelector`    | string    | "table"                        | CSS selector for the table to scrape                                        |
-| `tableColumns`   | array     | [1,2,3]                        | Columns to display (1-based index)                                          |
-| `tableRows`      | array     | []                             | Rows to display (1-based index, empty for all)                              |
-| `showTableHeader`| boolean   | true                           | Show the table header row                                                   |
-| `plainText`      | boolean   | false                          | Display only plain text (no HTML)                                           |
-| `waitForSelector`| boolean   | false                          | Wait for selector (for JS-loaded tables, requires Puppeteer)                |
-| `browserPath`    | string    | "/usr/bin/chromium-browser"    | Path to Chromium/Chrome for Puppeteer                                       |
-| `tableWidth`     | string    | "100%"                         | CSS width for the table (e.g., "100%", "1200px")                            |
+| Option            | Type      | Default                        | Description                                                                 |
+|-------------------|-----------|--------------------------------|-----------------------------------------------------------------------------|
+| `title`           | string    | "Scrapey Data"                 | Module header text                                                          |
+| `url`             | string    | *required*                     | URL of the page to scrape                                                   |
+| `updateInterval`  | int       | 60                             | Refresh interval in seconds                                                 |
+| `cssSelector`     | string    | "table"                        | CSS selector for the table to scrape                                        |
+| `tableColumns`    | array     | [1,2,3]                        | Columns to display (1-based index)                                          |
+| `tableRows`       | array     | []                             | Rows to display (1-based index, empty for all)                              |
+| `showTableHeader` | boolean   | true                           | Show the table header row                                                   |
+| `plainText`       | boolean   | false                          | Display only plain text (no HTML)                                           |
+| `waitForSelector` | boolean   | false                          | Wait for selector (for JS-loaded tables, requires Puppeteer)                |
+| `browserPath`     | string    | "/usr/bin/chromium-browser"    | Path to Chromium/Chrome for Puppeteer                                       |
+| `tableWidth`      | string    | "100%"                         | CSS width for the table (e.g., "100%", "1200px")                            |
+| `brightText`      | boolean   | false                          | Use MagicMirror's bright text style for the table                           |
 
 ---
 
-For troubleshooting Puppeteer or browser issues, see
+For troubleshooting Puppeteer or browser issues, see [Puppeteer Troubleshooting](https://pptr.dev/troubleshooting).
+
+---
+
+### Bright Text Example
+
+To enable brighter text for your table (for better visibility on dark backgrounds), add the following to your config:
+
+```js
+config: {
+    // ...other config...
+    brightText: true
+}
+```
+
+This will apply MagicMirror's standard `.bright` class to your table.

--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ npm install
 | `waitForSelector` | boolean   | false                          | Wait for selector (for JS-loaded tables, requires Puppeteer)                |
 | `browserPath`     | string    | "/usr/bin/chromium-browser"    | Path to Chromium/Chrome for Puppeteer                                       |
 | `tableWidth`      | string    | "100%"                         | CSS width for the table (e.g., "100%", "1200px")                            |
-| `rowOpacity`      | number\|null | null                        | Opacity for table rows (0.0–1.0, null for no style)                         |
-| `headerOpacity`   | number\|null | null                        | Opacity for table header (0.0–1.0, null for no style)                       |
+| `headerStyle`     | object    | `{ opacity: null, color: null }` | Style for table header: set `opacity` (0.0–1.0, null for no style) and/or `color` (e.g., "#fff") |
+| `rowStyle`        | object    | `{ opacity: null, color: null }` | Style for table rows: set `opacity` (0.0–1.0, null for no style) and/or `color` (e.g., "#fff")   |

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ npm install
 | `browserPath`     | string    | "/usr/bin/chromium-browser"    | Path to Chromium/Chrome for Puppeteer                                       |
 | `tableWidth`      | string    | "100%"                         | CSS width for the table (e.g., "100%", "1200px")                            |
 | `brightText`      | boolean   | false                          | Use bright white text and subtle glow for the table                         |
-| `rowOpacity`      | number    | 0.92                           | Opacity for table rows (0.0–1.0, ignored if `brightText` is true)           |
+| `rowOpacity`      | number    | 0.92                           | Opacity for table rows (0.0–1.0, ignored if `brightText` is `false`)           |

--- a/README.md
+++ b/README.md
@@ -75,23 +75,5 @@ npm install
 | `waitForSelector` | boolean   | false                          | Wait for selector (for JS-loaded tables, requires Puppeteer)                |
 | `browserPath`     | string    | "/usr/bin/chromium-browser"    | Path to Chromium/Chrome for Puppeteer                                       |
 | `tableWidth`      | string    | "100%"                         | CSS width for the table (e.g., "100%", "1200px")                            |
-| `brightText`      | boolean   | false                          | Use MagicMirror's bright text style for the table                           |
-
----
-
-For troubleshooting Puppeteer or browser issues, see [Puppeteer Troubleshooting](https://pptr.dev/troubleshooting).
-
----
-
-### Bright Text Example
-
-To enable brighter text for your table (for better visibility on dark backgrounds), add the following to your config:
-
-```js
-config: {
-    // ...other config...
-    brightText: true
-}
-```
-
-This will apply MagicMirror's standard `.bright` class to your table.
+| `brightText`      | boolean   | false                          | Use bright white text and subtle glow for the table                         |
+| `rowOpacity`      | number    | 0.92                           | Opacity for table rows (0.0–1.0, ignored if `brightText` is true)           |


### PR DESCRIPTION
## Pull Request: Add Configurable Header and Row Styles (Opacity & Color)
<img width="405" height="362" alt="image" src="https://github.com/user-attachments/assets/ea96d57e-2b5f-4418-a8bb-401041706517" />


### What's Changed

- **New Config Options:**
  - `headerStyle`: Object with `opacity` and `color` properties to control the table header's appearance.
  - `rowStyle`: Object with `opacity` and `color` properties to control the table rows' appearance.

- **Usage Example:**
    ```js
    config: {
        headerStyle: { opacity: 1, color: "#fff" },
        rowStyle: { opacity: 0.85, color: "#eee" }
    }
    ```

- **Behavior:**
  - If `opacity` or `color` is set to `null`, that style is not applied.
  - Styles are applied inline to ensure they are respected regardless of MagicMirror theme.

- **README Updated:**  
  - Documentation now reflects the new nested style options and provides usage examples.

---

**These changes give users fine-grained control over the look of their scraped tables, improving both readability and integration with custom MagicMirror themes.**